### PR TITLE
VoidSqlSchema

### DIFF
--- a/core/src/Module/Sql/Helper/VoidSqlSchema.php
+++ b/core/src/Module/Sql/Helper/VoidSqlSchema.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Harmony\Core\Module\Sql\Helper;
+
+use Harmony\Core\Shared\Error\MethodNotImplementedException;
+
+class VoidSqlSchema implements SqlSchema {
+  /**
+   * @throws MethodNotImplementedException
+   */
+  public function getTableName(): string {
+    throw new MethodNotImplementedException();
+  }
+
+  /**
+   * @throws MethodNotImplementedException
+   */
+  public function getIdColumn(): string {
+    throw new MethodNotImplementedException();
+  }
+
+  /**
+   * @throws MethodNotImplementedException
+   */
+  public function getKeyColumn(): string {
+    throw new MethodNotImplementedException();
+  }
+}


### PR DESCRIPTION
In order to provide a void implementation for the SqlSchema interface, VoidSqlSchema will allow us to inject an SqlSchema to the datasources who don't need the provided methods of SqlSchema.