### PR TITLE
BACKEND-4475 :: FEATURE :: Add a count option into the RawSqlDatasource

### DIFF
--- a/core/src/Domain/Interactor/DeleteInteractor.php
+++ b/core/src/Domain/Interactor/DeleteInteractor.php
@@ -11,12 +11,6 @@ class DeleteInteractor {
   public function __construct(protected DeleteRepository $deleteRepository) {
   }
 
-  /**
-   * @param Query $query
-   * @param Operation|null $operation
-   *
-   * @return void
-   */
   public function __invoke(Query $query, ?Operation $operation = null): void {
     $operation = $operation ?? new DefaultOperation();
     $this->deleteRepository->delete($query, $operation);

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -8,9 +8,12 @@ use Harmony\Core\Repository\Operation\Operation;
 use Harmony\Core\Repository\Query\CountAllQuery;
 use Harmony\Core\Repository\Query\Query;
 
+/**
+ * @template T
+ */
 class GetCountInteractor {
   /**
-   * @param GetRepository<int> $getRepository
+   * @param GetRepository<T> $getRepository
    */
   public function __construct(protected GetRepository $getRepository) {
   }

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -22,6 +22,8 @@ class GetCountInteractor {
     $query = $query ?? new CountAllQuery();
     $operation = $operation ?? new DefaultOperation();
 
-    return $this->getRepository->get($query, $operation);
+    $result = $this->getRepository->get($query, $operation);
+
+    return $result;
   }
 }

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -5,28 +5,25 @@ namespace Harmony\Core\Domain\Interactor;
 use Harmony\Core\Repository\GetRepository;
 use Harmony\Core\Repository\Operation\DefaultOperation;
 use Harmony\Core\Repository\Operation\Operation;
-use Harmony\Core\Repository\Query\AllQuery;
+use Harmony\Core\Repository\Query\CountAllQuery;
 use Harmony\Core\Repository\Query\Query;
 
 /**
  * @template T
  */
-class GetAllInteractor {
+class GetCountInteractor {
   /**
    * @param GetRepository<T> $getRepository
    */
   public function __construct(protected GetRepository $getRepository) {
   }
 
-  /**
-   * @return array<T>
-   */
   public function __invoke(
     ?Query $query = null,
     ?Operation $operation = null
-  ): array {
-    $query = $query ?? new AllQuery();
+  ): int {
+    $query = $query ?? new CountAllQuery();
     $operation = $operation ?? new DefaultOperation();
-    return $this->getRepository->getAll($query, $operation);
+    return $this->getRepository->getCount($query, $operation);
   }
 }

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -9,6 +9,9 @@ use Harmony\Core\Repository\Query\CountAllQuery;
 use Harmony\Core\Repository\Query\Query;
 
 class GetCountInteractor {
+  /**
+   * @param GetRepository<int> $getRepository
+   */
   public function __construct(protected GetRepository $getRepository) {
   }
 

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -8,13 +8,7 @@ use Harmony\Core\Repository\Operation\Operation;
 use Harmony\Core\Repository\Query\CountAllQuery;
 use Harmony\Core\Repository\Query\Query;
 
-/**
- * @template T
- */
 class GetCountInteractor {
-  /**
-   * @param GetRepository<T> $getRepository
-   */
   public function __construct(protected GetRepository $getRepository) {
   }
 
@@ -24,6 +18,7 @@ class GetCountInteractor {
   ): int {
     $query = $query ?? new CountAllQuery();
     $operation = $operation ?? new DefaultOperation();
+
     return $this->getRepository->getCount($query, $operation);
   }
 }

--- a/core/src/Domain/Interactor/GetCountInteractor.php
+++ b/core/src/Domain/Interactor/GetCountInteractor.php
@@ -8,12 +8,9 @@ use Harmony\Core\Repository\Operation\Operation;
 use Harmony\Core\Repository\Query\CountAllQuery;
 use Harmony\Core\Repository\Query\Query;
 
-/**
- * @template T
- */
 class GetCountInteractor {
   /**
-   * @param GetRepository<T> $getRepository
+   * @param GetRepository<int> $getRepository
    */
   public function __construct(protected GetRepository $getRepository) {
   }
@@ -25,6 +22,6 @@ class GetCountInteractor {
     $query = $query ?? new CountAllQuery();
     $operation = $operation ?? new DefaultOperation();
 
-    return $this->getRepository->getCount($query, $operation);
+    return $this->getRepository->get($query, $operation);
   }
 }

--- a/core/src/Domain/Interactor/GetInteractor.php
+++ b/core/src/Domain/Interactor/GetInteractor.php
@@ -19,10 +19,6 @@ class GetInteractor {
   }
 
   /**
-   * @param Query|null $query
-   * @param Operation|null $operation
-   *
-   * @return mixed
    * @phpstan-return T
    */
   public function __invoke(

--- a/core/src/Module/Pdo/PdoWrapper.php
+++ b/core/src/Module/Pdo/PdoWrapper.php
@@ -18,6 +18,8 @@ class PdoWrapper implements SqlInterface {
   }
 
   /**
+   * @psalm-suppress MoreSpecificImplementedParamType
+   *
    * @param string $sql
    * @param array<string, mixed> $params
    *

--- a/core/src/Repository/DataSource/DataSourceMapper.php
+++ b/core/src/Repository/DataSource/DataSourceMapper.php
@@ -11,7 +11,10 @@ use Harmony\Core\Repository\Query\Query;
  * @implements GetDataSource<TEntity>
  * @implements PutDataSource<TEntity>
  */
-class DataSourceMapper implements GetDataSource, PutDataSource, DeleteDataSource {
+class DataSourceMapper implements
+  GetDataSource,
+  PutDataSource,
+  DeleteDataSource {
   /**
    * @param GetDataSource<TData>   $getDataSource
    * @param PutDataSource<TData>   $putDataSource
@@ -50,6 +53,15 @@ class DataSourceMapper implements GetDataSource, PutDataSource, DeleteDataSource
     }
 
     return $entities;
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(Query $query): int {
+    $count = $this->getDataSource->getCount($query);
+
+    return $count;
   }
 
   /**

--- a/core/src/Repository/DataSource/DataSourceMapper.php
+++ b/core/src/Repository/DataSource/DataSourceMapper.php
@@ -55,9 +55,6 @@ class DataSourceMapper implements
     return $entities;
   }
 
-  /**
-   * @inheritdoc
-   */
   public function getCount(Query $query): int {
     $count = $this->getDataSource->getCount($query);
 
@@ -110,9 +107,6 @@ class DataSourceMapper implements
     return $entitiesPutted;
   }
 
-  /**
-   * @inheritdoc
-   */
   public function delete(Query $query): void {
     $this->deleteDataSource->delete($query);
   }

--- a/core/src/Repository/DataSource/DataSourceMapper.php
+++ b/core/src/Repository/DataSource/DataSourceMapper.php
@@ -55,12 +55,6 @@ class DataSourceMapper implements
     return $entities;
   }
 
-  public function getCount(Query $query): int {
-    $count = $this->getDataSource->getCount($query);
-
-    return $count;
-  }
-
   /**
    * @param Query        $query
    * @param TEntity|null $entity

--- a/core/src/Repository/DataSource/DeleteDataSource.php
+++ b/core/src/Repository/DataSource/DeleteDataSource.php
@@ -5,10 +5,5 @@ namespace Harmony\Core\Repository\DataSource;
 use Harmony\Core\Repository\Query\Query;
 
 interface DeleteDataSource {
-  /**
-   * @param Query $query
-   *
-   * @return void
-   */
   public function delete(Query $query): void;
 }

--- a/core/src/Repository/DataSource/GetDataSource.php
+++ b/core/src/Repository/DataSource/GetDataSource.php
@@ -17,6 +17,4 @@ interface GetDataSource {
    * @return array<T>
    */
   public function getAll(Query $query): array;
-
-  public function getCount(Query $query): int;
 }

--- a/core/src/Repository/DataSource/GetDataSource.php
+++ b/core/src/Repository/DataSource/GetDataSource.php
@@ -9,23 +9,14 @@ use Harmony\Core\Repository\Query\Query;
  */
 interface GetDataSource {
   /**
-   * @param Query $query
-   *
    * @return T
    */
   public function get(Query $query);
 
   /**
-   * @param Query $query
-   *
    * @return array<T>
    */
   public function getAll(Query $query): array;
 
-  /**
-   * @param Query $query
-   *
-   * @return int
-   */
   public function getCount(Query $query): int;
 }

--- a/core/src/Repository/DataSource/GetDataSource.php
+++ b/core/src/Repository/DataSource/GetDataSource.php
@@ -21,4 +21,11 @@ interface GetDataSource {
    * @return array<T>
    */
   public function getAll(Query $query): array;
+
+  /**
+   * @param Query $query
+   *
+   * @return int
+   */
+  public function getCount(Query $query): int;
 }

--- a/core/src/Repository/DataSource/InMemoryDataSource.php
+++ b/core/src/Repository/DataSource/InMemoryDataSource.php
@@ -5,6 +5,7 @@ namespace Harmony\Core\Repository\DataSource;
 use Harmony\Core\Repository\Error\DataNotFoundException;
 use Harmony\Core\Repository\Error\QueryNotSupportedException;
 use Harmony\Core\Repository\Query\AllQuery;
+use Harmony\Core\Repository\Query\Composed\CountQuery;
 use Harmony\Core\Repository\Query\KeyQuery;
 use Harmony\Core\Repository\Query\Query;
 use InvalidArgumentException;
@@ -14,7 +15,10 @@ use InvalidArgumentException;
  * @implements GetDataSource<T>
  * @implements PutDataSource<T>
  */
-class InMemoryDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
+class InMemoryDataSource implements
+  GetDataSource,
+  PutDataSource,
+  DeleteDataSource {
   /** @var array<mixed, T> */
   protected $entities = [];
 
@@ -23,9 +27,7 @@ class InMemoryDataSource implements GetDataSource, PutDataSource, DeleteDataSour
    *
    * @param string                $genericClass
    */
-  public function __construct(
-    protected string $genericClass
-  ) {
+  public function __construct(protected string $genericClass) {
   }
 
   /**
@@ -56,6 +58,19 @@ class InMemoryDataSource implements GetDataSource, PutDataSource, DeleteDataSour
     }
 
     throw new QueryNotSupportedException();
+  }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(Query $query): int {
+    if (!$query instanceof CountQuery) {
+      throw new QueryNotSupportedException();
+    }
+
+    $count = count($this->entities);
+
+    return $count;
   }
 
   /**
@@ -104,6 +119,7 @@ class InMemoryDataSource implements GetDataSource, PutDataSource, DeleteDataSour
       }
 
       unset($this->entities[$query->geKey()]);
+
       return;
     }
 

--- a/core/src/Repository/DataSource/InMemoryDataSource.php
+++ b/core/src/Repository/DataSource/InMemoryDataSource.php
@@ -65,19 +65,6 @@ class InMemoryDataSource implements
   }
 
   /**
-   * @throws QueryNotSupportedException
-   */
-  public function getCount(Query $query): int {
-    if (!$query instanceof CountQuery) {
-      throw new QueryNotSupportedException();
-    }
-
-    $count = count($this->entities);
-
-    return $count;
-  }
-
-  /**
    * @inheritdoc
    * @throws QueryNotSupportedException
    */

--- a/core/src/Repository/DataSource/InMemoryDataSource.php
+++ b/core/src/Repository/DataSource/InMemoryDataSource.php
@@ -20,7 +20,7 @@ class InMemoryDataSource implements
   PutDataSource,
   DeleteDataSource {
   /** @var array<mixed, T> */
-  protected $entities = [];
+  protected array $entities = [];
 
   /**
    * @psalm-param class-string<T> $genericClass
@@ -32,6 +32,8 @@ class InMemoryDataSource implements
 
   /**
    * @inheritdoc
+   * @throws DataNotFoundException
+   * @throws QueryNotSupportedException
    */
   public function get(Query $query): mixed {
     if ($query instanceof KeyQuery) {
@@ -47,6 +49,8 @@ class InMemoryDataSource implements
 
   /**
    * @inheritdoc
+   * @throws DataNotFoundException
+   * @throws QueryNotSupportedException
    */
   public function getAll(Query $query): array {
     if ($query instanceof AllQuery) {
@@ -61,7 +65,7 @@ class InMemoryDataSource implements
   }
 
   /**
-   * @inheritdoc
+   * @throws QueryNotSupportedException
    */
   public function getCount(Query $query): int {
     if (!$query instanceof CountQuery) {
@@ -75,6 +79,7 @@ class InMemoryDataSource implements
 
   /**
    * @inheritdoc
+   * @throws QueryNotSupportedException
    */
   public function put(Query $query, mixed $entity = null): mixed {
     if ($entity === null) {
@@ -92,6 +97,7 @@ class InMemoryDataSource implements
 
   /**
    * @inheritdoc
+   * @throws QueryNotSupportedException
    */
   public function putAll(Query $query, array $entities = null): array {
     if ($entities === null) {
@@ -110,7 +116,8 @@ class InMemoryDataSource implements
   }
 
   /**
-   * @inheritdoc
+   * @throws DataNotFoundException
+   * @throws QueryNotSupportedException
    */
   public function delete(Query $query): void {
     if ($query instanceof KeyQuery) {

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -41,11 +41,11 @@ class RawSqlDataSource implements
    *
    * @param Query $query
    *
-   * @return object
+   * @return mixed
    * @throws DataNotFoundException
    * @throws QueryNotSupportedException
    */
-  public function get(Query $query): object {
+  public function get(Query $query): mixed {
     $sql = match (true) {
       $query instanceof IdQuery => $this->sqlBuilder->selectById(
         $query->getId(),
@@ -73,7 +73,7 @@ class RawSqlDataSource implements
    *
    * @param Query $query
    *
-   * @return object[]
+   * @return array
    * @throws DataNotFoundException
    * @throws QueryNotSupportedException
    */
@@ -93,28 +93,6 @@ class RawSqlDataSource implements
     }
 
     return $items;
-  }
-
-  /**
-   * @throws QueryNotSupportedException
-   * @throws DataNotFoundException
-   */
-  public function getCount(Query $query): int {
-    $sql = match (true) {
-      $query instanceof CountQuery => $this->sqlBuilder->selectComposed(
-        $query,
-      ),
-      default => throw new QueryNotSupportedException()
-    };
-
-    $result = $this->pdo->findOne($sql->sql(), $sql->params());
-
-    if ($result === null) {
-      throw new DataNotFoundException();
-    }
-
-    // @phpstan-ignore-next-line
-    return $result->count;
   }
 
   /**
@@ -166,7 +144,7 @@ class RawSqlDataSource implements
    * @param Query         $query
    * @param object[]|null $entities
    *
-   * @return object[]
+   * @return array
    * @throws QueryNotSupportedException
    */
   public function putAll(Query $query, array $entities = null): array {

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -97,6 +97,7 @@ class RawSqlDataSource implements
 
   /**
    * @throws QueryNotSupportedException
+   * @throws DataNotFoundException
    */
   public function getCount(Query $query): int {
     $sql = match (true) {
@@ -106,9 +107,14 @@ class RawSqlDataSource implements
       default => throw new QueryNotSupportedException()
     };
 
-    $item = $this->pdo->findOne($sql->sql(), $sql->params());
+    $result = $this->pdo->findOne($sql->sql(), $sql->params());
 
-    return $item?->count;
+    if ($result === null) {
+      throw new DataNotFoundException();
+    }
+
+    // @phpstan-ignore-next-line
+    return $result->count;
   }
 
   /**
@@ -150,6 +156,7 @@ class RawSqlDataSource implements
     } elseif ($entity?->$idCol) {
       $id = $entity->$idCol;
     }
+
     return $id;
   }
 

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -11,6 +11,7 @@ use Harmony\Core\Repository\Error\DataNotFoundException;
 use Harmony\Core\Repository\Error\QueryNotSupportedException;
 use Harmony\Core\Repository\Query\AllQuery;
 use Harmony\Core\Repository\Query\Composed\ComposedQuery;
+use Harmony\Core\Repository\Query\Composed\CountQuery;
 use Harmony\Core\Repository\Query\IdQuery;
 use Harmony\Core\Repository\Query\KeyQuery;
 use Harmony\Core\Repository\Query\Query;
@@ -92,6 +93,21 @@ class RawSqlDataSource implements
     }
 
     return $items;
+  }
+
+  /**
+   * @throws QueryNotSupportedException
+   */
+  public function getCount(Query $query): int {
+    $sql = match (true) {
+      $query instanceof CountQuery => $this->sqlBuilder->selectComposed(
+        $query,
+      ),
+      default => throw new QueryNotSupportedException()
+    };
+
+    $item = $this->pdo->findOne($sql->sql(), $sql->params());
+    return $item->count;
   }
 
   /**

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -107,7 +107,8 @@ class RawSqlDataSource implements
     };
 
     $item = $this->pdo->findOne($sql->sql(), $sql->params());
-    return $item->count;
+
+    return $item?->count;
   }
 
   /**

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -38,6 +38,7 @@ class RawSqlDataSource implements
 
   /**
    * @psalm-suppress ImplementedReturnTypeMismatch
+   * @psalm-suppress LessSpecificImplementedReturnType
    *
    * @param Query $query
    *
@@ -70,10 +71,11 @@ class RawSqlDataSource implements
 
   /**
    * @psalm-suppress ImplementedReturnTypeMismatch
+   * @psalm-suppress LessSpecificImplementedReturnType
    *
    * @param Query $query
    *
-   * @return array
+   * @return mixed[]
    * @throws DataNotFoundException
    * @throws QueryNotSupportedException
    */
@@ -140,11 +142,12 @@ class RawSqlDataSource implements
 
   /**
    * @psalm-suppress MoreSpecificImplementedParamType
+   * @psalm-suppress LessSpecificImplementedReturnType
    *
    * @param Query         $query
    * @param object[]|null $entities
    *
-   * @return array
+   * @return mixed[]
    * @throws QueryNotSupportedException
    */
   public function putAll(Query $query, array $entities = null): array {

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -67,6 +67,7 @@ class RawSqlDataSource implements
     }
 
     if ($query instanceof CountQuery) {
+      // @phpstan-ignore-next-line
       $item = $item->count;
     }
 

--- a/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/RawSqlDataSource.php
@@ -66,6 +66,10 @@ class RawSqlDataSource implements
       throw new DataNotFoundException();
     }
 
+    if ($query instanceof CountQuery) {
+      $item = $item->count;
+    }
+
     return $item;
   }
 

--- a/core/src/Repository/DataSource/Sql/DataSource/SqlInterface.php
+++ b/core/src/Repository/DataSource/Sql/DataSource/SqlInterface.php
@@ -4,8 +4,8 @@ namespace Harmony\Core\Repository\DataSource\Sql\DataSource;
 
 interface SqlInterface {
   /**
-   * @param string               $sql
-   * @param array<mixed>         $params
+   * @param string                  $sql
+   * @param array<string, mixed> $params
    *
    * @return object|null
    */
@@ -28,7 +28,7 @@ interface SqlInterface {
   public function insert(string $sql, array $params): int|string;
 
   /**
-   * @param string $sql
+   * @param string               $sql
    * @param array<string, mixed> $params
    *
    * @return bool

--- a/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
+++ b/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
@@ -2,17 +2,18 @@
 
 namespace Harmony\Core\Repository\DataSource\Sql\Helper;
 
-use Harmony\Core\Repository\Query\Query;
 use Harmony\Core\Repository\DataSource\Sql\SqlBaseColumn;
 use Harmony\Core\Repository\Query\Composed\ComposedQuery;
 use Harmony\Core\Repository\Query\Composed\CountQuery;
 use Harmony\Core\Repository\Query\Composed\OrderByQuery;
 use Harmony\Core\Repository\Query\Composed\PaginationOffsetLimitQuery;
 use Harmony\Core\Repository\Query\Composed\WhereQuery;
-use Latitude\QueryBuilder\Query\SelectQuery;
+use Harmony\Core\Repository\Query\Query;
 use Latitude\QueryBuilder\Query as SqlQuery;
+use Latitude\QueryBuilder\Query\SelectQuery;
 use Latitude\QueryBuilder\Query\UpdateQuery;
 use Latitude\QueryBuilder\QueryFactory;
+use function Latitude\QueryBuilder\alias;
 use function Latitude\QueryBuilder\field;
 use function Latitude\QueryBuilder\func;
 
@@ -66,6 +67,7 @@ class SqlBuilder {
     }
 
     $query = $factory->compile();
+
     return $query;
   }
 
@@ -75,12 +77,11 @@ class SqlBuilder {
     $factory = $this->addWhereConditions($composed, $factory);
 
     if ($composed instanceof CountQuery) {
-      $factory = $this->factory->select(
-        alias(func("COUNT", '*'), 'count')
-      );
+      $factory = $this->factory->select(alias(func("COUNT", "*"), "count"));
     }
 
     $query = $factory->compile();
+
     return $query;
   }
 
@@ -101,6 +102,7 @@ class SqlBuilder {
     $factory = $this->addWhereConditions($composed, $factory);
 
     $query = $factory->compile();
+
     return $query;
   }
 
@@ -139,6 +141,7 @@ class SqlBuilder {
     }
 
     $query = $factory->compile();
+
     return $query;
   }
 
@@ -161,7 +164,7 @@ class SqlBuilder {
   }
 
   /**
-   * @param Query $query
+   * @param Query                   $query
    * @param SelectQuery|UpdateQuery $factory
    *
    * @return SelectQuery|UpdateQuery

--- a/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
+++ b/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
@@ -5,6 +5,7 @@ namespace Harmony\Core\Repository\DataSource\Sql\Helper;
 use Harmony\Core\Repository\Query\Query;
 use Harmony\Core\Repository\DataSource\Sql\SqlBaseColumn;
 use Harmony\Core\Repository\Query\Composed\ComposedQuery;
+use Harmony\Core\Repository\Query\Composed\CountQuery;
 use Harmony\Core\Repository\Query\Composed\OrderByQuery;
 use Harmony\Core\Repository\Query\Composed\PaginationOffsetLimitQuery;
 use Harmony\Core\Repository\Query\Composed\WhereQuery;
@@ -72,6 +73,12 @@ class SqlBuilder {
     $factory = $this->factory->select()->from($this->schema->getTableName());
 
     $factory = $this->addWhereConditions($composed, $factory);
+
+    if ($composed instanceof CountQuery) {
+      $factory = $this->factory->select(
+        alias(func("COUNT", '*'), 'count')
+      );
+    }
 
     $query = $factory->compile();
     return $query;

--- a/core/src/Repository/DataSource/Sql/SqlBaseColumn.php
+++ b/core/src/Repository/DataSource/Sql/SqlBaseColumn.php
@@ -3,9 +3,9 @@
 namespace Harmony\Core\Repository\DataSource\Sql;
 
 class SqlBaseColumn {
-  const ID = "id";
-  const UUID = "uuid";
-  const CREATED_AT = "created_at";
-  const UPDATED_AT = "updated_at";
-  const DELETED_AT = "deleted_at";
+  public const ID = "id";
+  public const UUID = "uuid";
+  public const CREATED_AT = "created_at";
+  public const UPDATED_AT = "updated_at";
+  public const DELETED_AT = "deleted_at";
 }

--- a/core/src/Repository/DataSource/Sql/SqlOrderDirection.php
+++ b/core/src/Repository/DataSource/Sql/SqlOrderDirection.php
@@ -3,6 +3,6 @@
 namespace Harmony\Core\Repository\DataSource\Sql;
 
 class SqlOrderDirection {
-  const ASC = "asc";
-  const DESC = "desc";
+  public const ASC = "asc";
+  public const DESC = "desc";
 }

--- a/core/src/Repository/DataSource/Sql/SqlRepositoryFactory.php
+++ b/core/src/Repository/DataSource/Sql/SqlRepositoryFactory.php
@@ -16,19 +16,12 @@ class SqlRepositoryFactory {
     QueryFactory $queryFactory,
     SqlSchema $schema
   ): GetCountInteractor {
-    $sqlBuilder = new SqlBuilder(
-      $schema,
-      $queryFactory,
-    );
+    $sqlBuilder = new SqlBuilder($schema, $queryFactory);
 
-    $dataSource = new RawSqlDataSource(
-      $pdo,
-      $sqlBuilder
-    );
+    $dataSource = new RawSqlDataSource($pdo, $sqlBuilder);
 
-    $countRepository = new SingleGetDataSourceRepository(
-      $dataSource,
-    );
+    /** @var SingleGetDataSourceRepository<int> $countRepository */
+    $countRepository = new SingleGetDataSourceRepository($dataSource);
 
     return new GetCountInteractor($countRepository);
   }

--- a/core/src/Repository/DataSource/Sql/SqlRepositoryFactory.php
+++ b/core/src/Repository/DataSource/Sql/SqlRepositoryFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Harmony\Core\Repository\DataSource\Sql;
+
+use Harmony\Core\Domain\Interactor\GetCountInteractor;
+use Harmony\Core\Module\Pdo\PdoWrapper;
+use Harmony\Core\Repository\DataSource\Sql\DataSource\RawSqlDataSource;
+use Harmony\Core\Repository\DataSource\Sql\Helper\SqlBuilder;
+use Harmony\Core\Repository\DataSource\Sql\Helper\SqlSchema;
+use Harmony\Core\Repository\SingleGetDataSourceRepository;
+use Latitude\QueryBuilder\QueryFactory;
+
+class SqlRepositoryFactory {
+  public static function getCountInteractor(
+    PdoWrapper $pdo,
+    QueryFactory $queryFactory,
+    SqlSchema $schema
+  ): GetCountInteractor {
+    $sqlBuilder = new SqlBuilder(
+      $schema,
+      $queryFactory,
+    );
+
+    $dataSource = new RawSqlDataSource(
+      $pdo,
+      $sqlBuilder
+    );
+
+    $countRepository = new SingleGetDataSourceRepository(
+      $dataSource,
+    );
+
+    return new GetCountInteractor($countRepository);
+  }
+}

--- a/core/src/Repository/DataSource/VoidDataSource.php
+++ b/core/src/Repository/DataSource/VoidDataSource.php
@@ -28,13 +28,6 @@ class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
   }
 
   /**
-   * @throws MethodNotImplementedException
-   */
-  public function getCount(Query $query): int {
-    throw new MethodNotImplementedException();
-  }
-
-  /**
    * @inheritdoc
    * @throws MethodNotImplementedException
    */

--- a/core/src/Repository/DataSource/VoidDataSource.php
+++ b/core/src/Repository/DataSource/VoidDataSource.php
@@ -13,6 +13,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function get(Query $query): mixed {
     throw new MethodNotImplementedException();
@@ -20,13 +21,14 @@ class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getAll(Query $query): array {
     throw new MethodNotImplementedException();
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getCount(Query $query): int {
     throw new MethodNotImplementedException();
@@ -34,6 +36,7 @@ class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function put(Query $query, mixed $entity = null): mixed {
     throw new MethodNotImplementedException();
@@ -41,13 +44,14 @@ class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function putAll(Query $query, array $entities = null): array {
     throw new MethodNotImplementedException();
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function delete(Query $query): void {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/DataSource/VoidDataSource.php
+++ b/core/src/Repository/DataSource/VoidDataSource.php
@@ -28,6 +28,13 @@ class VoidDataSource implements GetDataSource, PutDataSource, DeleteDataSource {
   /**
    * @inheritdoc
    */
+  public function getCount(Query $query): int {
+    throw new MethodNotImplementedException();
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function put(Query $query, mixed $entity = null): mixed {
     throw new MethodNotImplementedException();
   }

--- a/core/src/Repository/DataSource/VoidDeleteDataSource.php
+++ b/core/src/Repository/DataSource/VoidDeleteDataSource.php
@@ -7,7 +7,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 
 class VoidDeleteDataSource implements DeleteDataSource {
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function delete(Query $query): void {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/DataSource/VoidGetDataSource.php
+++ b/core/src/Repository/DataSource/VoidGetDataSource.php
@@ -23,4 +23,11 @@ class VoidGetDataSource implements GetDataSource {
   public function getAll(Query $query): array {
     throw new MethodNotImplementedException();
   }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(Query $query): int {
+    throw new MethodNotImplementedException();
+  }
 }

--- a/core/src/Repository/DataSource/VoidGetDataSource.php
+++ b/core/src/Repository/DataSource/VoidGetDataSource.php
@@ -12,6 +12,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 class VoidGetDataSource implements GetDataSource {
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function get(Query $query): mixed {
     throw new MethodNotImplementedException();
@@ -19,13 +20,14 @@ class VoidGetDataSource implements GetDataSource {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getAll(Query $query): array {
     throw new MethodNotImplementedException();
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getCount(Query $query): int {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/DataSource/VoidGetDataSource.php
+++ b/core/src/Repository/DataSource/VoidGetDataSource.php
@@ -25,11 +25,4 @@ class VoidGetDataSource implements GetDataSource {
   public function getAll(Query $query): array {
     throw new MethodNotImplementedException();
   }
-
-  /**
-   * @throws MethodNotImplementedException
-   */
-  public function getCount(Query $query): int {
-    throw new MethodNotImplementedException();
-  }
 }

--- a/core/src/Repository/DeleteRepository.php
+++ b/core/src/Repository/DeleteRepository.php
@@ -6,11 +6,5 @@ use Harmony\Core\Repository\Operation\Operation;
 use Harmony\Core\Repository\Query\Query;
 
 interface DeleteRepository extends Repository {
-  /**
-   * @param Query     $query     query
-   * @param Operation $operation operation
-   *
-   * @return void
-   */
   public function delete(Query $query, Operation $operation): void;
 }

--- a/core/src/Repository/GetRepository.php
+++ b/core/src/Repository/GetRepository.php
@@ -18,6 +18,4 @@ interface GetRepository extends Repository {
    * @return array<T>
    */
   public function getAll(Query $query, Operation $operation): array;
-
-  public function getCount(Query $query, Operation $operation): int;
 }

--- a/core/src/Repository/GetRepository.php
+++ b/core/src/Repository/GetRepository.php
@@ -10,26 +10,14 @@ use Harmony\Core\Repository\Query\Query;
  */
 interface GetRepository extends Repository {
   /**
-   * @param Query     $query     query
-   * @param Operation $operation operation
-   *
    * @return T
    */
   public function get(Query $query, Operation $operation);
 
   /**
-   * @param Query     $query
-   * @param Operation $operation
-   *
    * @return array<T>
    */
   public function getAll(Query $query, Operation $operation): array;
 
-  /**
-   * @param Query     $query     query
-   * @param Operation $operation operation
-   *
-   * @return int
-   */
   public function getCount(Query $query, Operation $operation): int;
 }

--- a/core/src/Repository/GetRepository.php
+++ b/core/src/Repository/GetRepository.php
@@ -24,4 +24,12 @@ interface GetRepository extends Repository {
    * @return array<T>
    */
   public function getAll(Query $query, Operation $operation): array;
+
+  /**
+   * @param Query     $query     query
+   * @param Operation $operation operation
+   *
+   * @return int
+   */
+  public function getCount(Query $query, Operation $operation): int;
 }

--- a/core/src/Repository/Mapper/BlankMapper.php
+++ b/core/src/Repository/Mapper/BlankMapper.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Harmony\Core\Repository\Mapper;
+
+/**
+ * @template T
+ * @implements Mapper<T, T>
+ */
+Class BlankMapper implements Mapper {
+    public function __construct() {
+    }
+
+    /**
+     * @param T $from
+     * @return T
+     */
+    public function map(mixed $from): mixed {
+        return $from;
+    }
+}

--- a/core/src/Repository/PutRepository.php
+++ b/core/src/Repository/PutRepository.php
@@ -10,17 +10,13 @@ use Harmony\Core\Repository\Query\Query;
  */
 interface PutRepository extends Repository {
   /**
-   * @param Query     $query
-   * @param Operation $operation
    * @param T|null    $model
    *
    * @return T
    */
-  public function put(Query $query, Operation $operation, $model = null);
+  public function put(Query $query, Operation $operation, mixed $model = null);
 
   /**
-   * @param Query         $query
-   * @param Operation     $operation
    * @param array<T>|null $models
    *
    * @return array<T>

--- a/core/src/Repository/Query/CountAllQuery.php
+++ b/core/src/Repository/Query/CountAllQuery.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Harmony\Core\Repository\Query;
+
+use Harmony\Core\Repository\Query\Composed\CountQuery;
+
+class CountAllQuery implements CountQuery {
+}

--- a/core/src/Repository/RepositoryMapper.php
+++ b/core/src/Repository/RepositoryMapper.php
@@ -58,10 +58,6 @@ class RepositoryMapper implements
     return $models;
   }
 
-  public function getCount(Query $query, Operation $operation): int {
-    return $this->getRepository->getCount($query, $operation);
-  }
-
   /**
    * @inheritdoc
    */

--- a/core/src/Repository/RepositoryMapper.php
+++ b/core/src/Repository/RepositoryMapper.php
@@ -58,6 +58,13 @@ class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository
   /**
    * @inheritdoc
    */
+  public function getCount(Query $query, Operation $operation): int {
+    return $this->getRepository->getCount($query, $operation);
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function put(Query $query, Operation $operation, $model = null) {
     $entity = null;
 

--- a/core/src/Repository/RepositoryMapper.php
+++ b/core/src/Repository/RepositoryMapper.php
@@ -12,7 +12,10 @@ use Harmony\Core\Repository\Query\Query;
  * @implements GetRepository<TModel>
  * @implements PutRepository<TModel>
  */
-class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository {
+class RepositoryMapper implements
+  GetRepository,
+  PutRepository,
+  DeleteRepository {
   /**
    * RepositoryMapper constructor.
    *
@@ -55,9 +58,6 @@ class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository
     return $models;
   }
 
-  /**
-   * @inheritdoc
-   */
   public function getCount(Query $query, Operation $operation): int {
     return $this->getRepository->getCount($query, $operation);
   }
@@ -81,7 +81,11 @@ class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository
   /**
    * @inheritdoc
    */
-  public function putAll(Query $query, Operation $operation, array $models = null): array {
+  public function putAll(
+    Query $query,
+    Operation $operation,
+    array $models = null
+  ): array {
     $entities = null;
 
     if ($models !== null) {
@@ -92,7 +96,11 @@ class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository
       }
     }
 
-    $entitiesPutted = $this->putRepository->putAll($query, $operation, $entities);
+    $entitiesPutted = $this->putRepository->putAll(
+      $query,
+      $operation,
+      $entities,
+    );
     $modelsPutted = [];
 
     foreach ($entitiesPutted as $entityPutted) {
@@ -102,9 +110,6 @@ class RepositoryMapper implements GetRepository, PutRepository, DeleteRepository
     return $modelsPutted;
   }
 
-  /**
-   * @inheritdoc
-   */
   public function delete(Query $query, Operation $operation): void {
     $this->deleteRepository->delete($query, $operation);
   }

--- a/core/src/Repository/SingleDataSourceRepository.php
+++ b/core/src/Repository/SingleDataSourceRepository.php
@@ -43,10 +43,6 @@ class SingleDataSourceRepository implements
     return $this->getDataSource->getAll($query);
   }
 
-  public function getCount(Query $query, Operation $operation): int {
-    return $this->getDataSource->getCount($query);
-  }
-
   /**
    * @inheritdoc
    */

--- a/core/src/Repository/SingleDataSourceRepository.php
+++ b/core/src/Repository/SingleDataSourceRepository.php
@@ -13,7 +13,10 @@ use Harmony\Core\Repository\Query\Query;
  * @implements GetRepository<T>
  * @implements PutRepository<T>
  */
-class SingleDataSourceRepository implements GetRepository, PutRepository, DeleteRepository {
+class SingleDataSourceRepository implements
+  GetRepository,
+  PutRepository,
+  DeleteRepository {
   /**
    * @param GetDataSource<T> $getDataSource
    * @param PutDataSource<T> $putDataSource
@@ -40,9 +43,6 @@ class SingleDataSourceRepository implements GetRepository, PutRepository, Delete
     return $this->getDataSource->getAll($query);
   }
 
-  /**
-   * @inheritdoc
-   */
   public function getCount(Query $query, Operation $operation): int {
     return $this->getDataSource->getCount($query);
   }
@@ -57,13 +57,14 @@ class SingleDataSourceRepository implements GetRepository, PutRepository, Delete
   /**
    * @inheritdoc
    */
-  public function putAll(Query $query, Operation $operation, array $models = null): array {
+  public function putAll(
+    Query $query,
+    Operation $operation,
+    array $models = null
+  ): array {
     return $this->putDataSource->putAll($query, $models);
   }
 
-  /**
-   * @inheritdoc
-   */
   public function delete(Query $query, Operation $operation): void {
     $this->deleteDataSource->delete($query);
   }

--- a/core/src/Repository/SingleDataSourceRepository.php
+++ b/core/src/Repository/SingleDataSourceRepository.php
@@ -43,6 +43,13 @@ class SingleDataSourceRepository implements GetRepository, PutRepository, Delete
   /**
    * @inheritdoc
    */
+  public function getCount(Query $query, Operation $operation): int {
+    return $this->getDataSource->getCount($query);
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function put(Query $query, Operation $operation, $model = null) {
     return $this->putDataSource->put($query, $model);
   }

--- a/core/src/Repository/SingleGetDataSourceRepository.php
+++ b/core/src/Repository/SingleGetDataSourceRepository.php
@@ -30,4 +30,11 @@ class SingleGetDataSourceRepository implements GetRepository {
   public function getAll(Query $query, Operation $operation): array {
     return $this->getDataSource->getAll($query);
   }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(Query $query, Operation $operation): int {
+    return $this->getDataSource->getCount($query);
+  }
 }

--- a/core/src/Repository/SingleGetDataSourceRepository.php
+++ b/core/src/Repository/SingleGetDataSourceRepository.php
@@ -31,9 +31,6 @@ class SingleGetDataSourceRepository implements GetRepository {
     return $this->getDataSource->getAll($query);
   }
 
-  /**
-   * @inheritdoc
-   */
   public function getCount(Query $query, Operation $operation): int {
     return $this->getDataSource->getCount($query);
   }

--- a/core/src/Repository/SingleGetDataSourceRepository.php
+++ b/core/src/Repository/SingleGetDataSourceRepository.php
@@ -30,8 +30,4 @@ class SingleGetDataSourceRepository implements GetRepository {
   public function getAll(Query $query, Operation $operation): array {
     return $this->getDataSource->getAll($query);
   }
-
-  public function getCount(Query $query, Operation $operation): int {
-    return $this->getDataSource->getCount($query);
-  }
 }

--- a/core/src/Repository/VoidDeleteRepository.php
+++ b/core/src/Repository/VoidDeleteRepository.php
@@ -8,7 +8,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 
 class VoidDeleteRepository implements DeleteRepository {
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function delete(Query $query, Operation $operation): void {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/VoidGetRepository.php
+++ b/core/src/Repository/VoidGetRepository.php
@@ -24,4 +24,11 @@ class VoidGetRepository implements GetRepository {
   public function getAll(Query $query, Operation $operation): array {
     throw new MethodNotImplementedException();
   }
+
+  /**
+   * @inheritdoc
+   */
+  public function getCount(Query $query, Operation $operation): int {
+    throw new MethodNotImplementedException();
+  }
 }

--- a/core/src/Repository/VoidGetRepository.php
+++ b/core/src/Repository/VoidGetRepository.php
@@ -26,11 +26,4 @@ class VoidGetRepository implements GetRepository {
   public function getAll(Query $query, Operation $operation): array {
     throw new MethodNotImplementedException();
   }
-
-  /**
-   * @throws MethodNotImplementedException
-   */
-  public function getCount(Query $query, Operation $operation): int {
-    throw new MethodNotImplementedException();
-  }
 }

--- a/core/src/Repository/VoidGetRepository.php
+++ b/core/src/Repository/VoidGetRepository.php
@@ -13,6 +13,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 class VoidGetRepository implements GetRepository {
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function get(Query $query, Operation $operation) {
     throw new MethodNotImplementedException();
@@ -20,13 +21,14 @@ class VoidGetRepository implements GetRepository {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getAll(Query $query, Operation $operation): array {
     throw new MethodNotImplementedException();
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getCount(Query $query, Operation $operation): int {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/VoidPutRepository.php
+++ b/core/src/Repository/VoidPutRepository.php
@@ -13,6 +13,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 class VoidPutRepository implements PutRepository {
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function put(Query $query, Operation $operation, $model = null) {
     throw new MethodNotImplementedException();
@@ -20,6 +21,7 @@ class VoidPutRepository implements PutRepository {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function putAll(
     Query $query,

--- a/core/src/Repository/VoidRepository.php
+++ b/core/src/Repository/VoidRepository.php
@@ -14,6 +14,7 @@ use Harmony\Core\Shared\Error\MethodNotImplementedException;
 class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function get(Query $query, Operation $operation) {
     throw new MethodNotImplementedException();
@@ -21,13 +22,14 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getAll(Query $query, Operation $operation): array {
     throw new MethodNotImplementedException();
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function getCount(Query $query, Operation $operation): int {
     throw new MethodNotImplementedException();
@@ -35,6 +37,7 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function put(Query $query, Operation $operation, $model = null) {
     throw new MethodNotImplementedException();
@@ -42,6 +45,7 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
 
   /**
    * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function putAll(
     Query $query,
@@ -52,7 +56,7 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
   }
 
   /**
-   * @inheritdoc
+   * @throws MethodNotImplementedException
    */
   public function delete(Query $query, Operation $operation): void {
     throw new MethodNotImplementedException();

--- a/core/src/Repository/VoidRepository.php
+++ b/core/src/Repository/VoidRepository.php
@@ -29,13 +29,6 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
   }
 
   /**
-   * @throws MethodNotImplementedException
-   */
-  public function getCount(Query $query, Operation $operation): int {
-    throw new MethodNotImplementedException();
-  }
-
-  /**
    * @inheritdoc
    * @throws MethodNotImplementedException
    */

--- a/core/src/Repository/VoidRepository.php
+++ b/core/src/Repository/VoidRepository.php
@@ -29,6 +29,13 @@ class VoidRepository implements GetRepository, PutRepository, DeleteRepository {
   /**
    * @inheritdoc
    */
+  public function getCount(Query $query, Operation $operation): int {
+    throw new MethodNotImplementedException();
+  }
+
+  /**
+   * @inheritdoc
+   */
   public function put(Query $query, Operation $operation, $model = null) {
     throw new MethodNotImplementedException();
   }


### PR DESCRIPTION
**Merge request information:**

- The GetInteractor have been expanded with a new `getCount` option which expects a query of type `CountQuery`. This way we avoid of creating different datasources or complex dependency injection modules. Having a default implementation and having a `where` method into the `CountQuery` most of the counting can be done with the new generic `CountInteractor`.

- Default queries have been changed in favor of a more simple call to very general purpose interactors.

* Example of implementation:
https://bitbucket.org/mobilejazz/socialpals-platform/pull-requests/1018/backend-9650-feature-change-the-way-we

* Asana task link:
* [BACKEND-4475 :: Add a count option into the RawSqlDatasource or as an independent DS. (Evaluation + implementation)](https://app.asana.com/0/1200574432121296/1202623630234475/f)
