### PR TITLE
BACKEND-1242 :: Feature :: Harmony PHP | Exception managing into generic Interactors 

### DIFF
--- a/core/src/Domain/Interactor/GetAllInteractor.php
+++ b/core/src/Domain/Interactor/GetAllInteractor.php
@@ -2,11 +2,12 @@
 
 namespace Harmony\Core\Domain\Interactor;
 
+use Harmony\Core\Repository\Error\DataNotFoundException;
 use Harmony\Core\Repository\GetRepository;
 use Harmony\Core\Repository\Operation\DefaultOperation;
 use Harmony\Core\Repository\Operation\Operation;
+use Harmony\Core\Repository\Query\AllQuery;
 use Harmony\Core\Repository\Query\Query;
-use Harmony\Core\Repository\Query\VoidQuery;
 
 /**
  * @template T
@@ -25,8 +26,12 @@ class GetAllInteractor {
     ?Query $query = null,
     ?Operation $operation = null,
   ): array {
-    $query = $query ?? new VoidQuery();
+    $query = $query ?? new AllQuery();
     $operation = $operation ?? new DefaultOperation();
-    return $this->getRepository->getAll($query, $operation);
+    try {
+      return $this->getRepository->getAll($query, $operation);
+    } catch (DataNotFoundException) {
+      return [];
+    }
   }
 }


### PR DESCRIPTION
**Asana task link:**
https://app.asana.com/0/1109863238977521/1203618657291242

**Pull request information:**
According to [our REST API agreement](https://harmony.mobilejazz.com/docs/agreements/rest-api), point 4, the getAll requests that don't match any result will return an empty array. This change is to set it as the default behaviour and avoid adding the same try - catch in every interactor.

Example about how we are currently working:
[socialPALS GetActiveCampaignsWithGoogleAdsInteractor](https://bitbucket.org/mobilejazz/socialpals-platform/src/249d9dfa059e/backend/src/app/Campaign/Domain/Interactor/GetActiveCampaignsWithGoogleAdsInteractor.php)