### PR TITLE
BACKEND-8104 :: Bug :: Harmony PHP | Readonly properties in child classes

### DIFF
--- a/core/src/Domain/Pagination/PaginationOffsetLimit.php
+++ b/core/src/Domain/Pagination/PaginationOffsetLimit.php
@@ -12,7 +12,7 @@ class PaginationOffsetLimit extends Pagination {
     /**
      * @var T[]       $values
      */
-    public readonly array $values,
+    array $values,
     public readonly int $offset,
     public readonly int $limit,
     public readonly int $size,

--- a/core/src/Domain/Pagination/PaginationOffsetLimit.php
+++ b/core/src/Domain/Pagination/PaginationOffsetLimit.php
@@ -8,10 +8,10 @@ namespace Harmony\Core\Domain\Pagination;
  * @psalm-suppress UndefinedDocblockClass
  */
 class PaginationOffsetLimit extends Pagination {
+  /**
+  * @param T[] $values
+  */
   public function __construct(
-    /**
-     * @var T[]       $values
-     */
     array $values,
     public readonly int $offset,
     public readonly int $limit,

--- a/core/src/Domain/Pagination/PaginationOffsetLimit.php
+++ b/core/src/Domain/Pagination/PaginationOffsetLimit.php
@@ -9,8 +9,8 @@ namespace Harmony\Core\Domain\Pagination;
  */
 class PaginationOffsetLimit extends Pagination {
   /**
-  * @param T[] $values
-  */
+   * @param T[] $values
+   */
   public function __construct(
     array $values,
     public readonly int $offset,

--- a/core/src/Repository/DataSource/GetDataSourceMapper.php
+++ b/core/src/Repository/DataSource/GetDataSourceMapper.php
@@ -16,9 +16,7 @@ class GetDataSourceMapper extends DataSourceMapper {
    * @param Mapper<TData, TEntity> $dataToEntityMapper
    */
   public function __construct(
-    // @phpstan-ignore-next-line
     GetDataSource $getDataSource,
-    // @phpstan-ignore-next-line
     Mapper $dataToEntityMapper,
   ) {
     /** @var VoidDataSource<TData> $voidDataSource */

--- a/core/src/Repository/DataSource/GetDataSourceMapper.php
+++ b/core/src/Repository/DataSource/GetDataSourceMapper.php
@@ -17,9 +17,9 @@ class GetDataSourceMapper extends DataSourceMapper {
    */
   public function __construct(
     // @phpstan-ignore-next-line
-    protected readonly GetDataSource $getDataSource,
+    GetDataSource $getDataSource,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $dataToEntityMapper,
+    Mapper $dataToEntityMapper,
   ) {
     /** @var VoidDataSource<TData> $voidDataSource */
     $voidDataSource = new VoidDataSource();
@@ -28,11 +28,11 @@ class GetDataSourceMapper extends DataSourceMapper {
     $voidMapper = new VoidMapper();
 
     parent::__construct(
-      $this->getDataSource,
+      $getDataSource,
       $voidDataSource,
       $voidDataSource,
       $voidMapper,
-      $this->dataToEntityMapper,
+      $dataToEntityMapper,
     );
   }
 }

--- a/core/src/Repository/DataSource/PutDataSourceMapper.php
+++ b/core/src/Repository/DataSource/PutDataSourceMapper.php
@@ -17,21 +17,21 @@ class PutDataSourceMapper extends DataSourceMapper {
    */
   public function __construct(
     // @phpstan-ignore-next-line
-    protected readonly PutDataSource $putDataSource,
+    PutDataSource $putDataSource,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $entityToDataMapper,
+    Mapper $entityToDataMapper,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $dataToEntityMapper,
+    Mapper $dataToEntityMapper,
   ) {
     /** @var VoidDataSource<TData> $voidDataSource */
     $voidDataSource = new VoidDataSource();
 
     parent::__construct(
       $voidDataSource,
-      $this->putDataSource,
+      $putDataSource,
       $voidDataSource,
-      $this->entityToDataMapper,
-      $this->dataToEntityMapper,
+      $entityToDataMapper,
+      $dataToEntityMapper,
     );
   }
 }

--- a/core/src/Repository/DataSource/PutDataSourceMapper.php
+++ b/core/src/Repository/DataSource/PutDataSourceMapper.php
@@ -16,11 +16,8 @@ class PutDataSourceMapper extends DataSourceMapper {
    * @param Mapper<TData, TEntity> $dataToEntityMapper
    */
   public function __construct(
-    // @phpstan-ignore-next-line
     PutDataSource $putDataSource,
-    // @phpstan-ignore-next-line
     Mapper $entityToDataMapper,
-    // @phpstan-ignore-next-line
     Mapper $dataToEntityMapper,
   ) {
     /** @var VoidDataSource<TData> $voidDataSource */

--- a/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
+++ b/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
@@ -210,10 +210,8 @@ class SqlBuilder {
         $field = field($where->field);
         $value = $where->value;
         $condition = match ($where->condition) {
-          /** @phpstan-ignore-next-line */
-          Criteria::In => $field->in(...$value),
-          /** @phpstan-ignore-next-line */
-          Criteria::NotIn => $field->notIn(...$value),
+          Criteria::In => $field->in(...(array) $value),
+          Criteria::NotIn => $field->notIn(...(array) $value),
           Criteria::Eq => $field->eq($value),
           Criteria::NotEq => $field->notEq($value),
           Criteria::Gt => $field->gt($value),

--- a/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
+++ b/core/src/Repository/DataSource/Sql/Helper/SqlBuilder.php
@@ -210,7 +210,9 @@ class SqlBuilder {
         $field = field($where->field);
         $value = $where->value;
         $condition = match ($where->condition) {
+          /** @phpstan-ignore-next-line */
           Criteria::In => $field->in(...$value),
+          /** @phpstan-ignore-next-line */
           Criteria::NotIn => $field->notIn(...$value),
           Criteria::Eq => $field->eq($value),
           Criteria::NotEq => $field->notEq($value),

--- a/core/src/Repository/GetRepositoryMapper.php
+++ b/core/src/Repository/GetRepositoryMapper.php
@@ -16,9 +16,7 @@ class GetRepositoryMapper extends RepositoryMapper {
    * @param Mapper<TEntity, TModel> $entityToModelMapper
    */
   public function __construct(
-    // @phpstan-ignore-next-line
     GetRepository $getRepository,
-    // @phpstan-ignore-next-line
     Mapper $entityToModelMapper,
   ) {
     /** @var VoidRepository<TEntity> $voidRepository */

--- a/core/src/Repository/GetRepositoryMapper.php
+++ b/core/src/Repository/GetRepositoryMapper.php
@@ -17,9 +17,9 @@ class GetRepositoryMapper extends RepositoryMapper {
    */
   public function __construct(
     // @phpstan-ignore-next-line
-    protected readonly GetRepository $getRepository,
+    GetRepository $getRepository,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $entityToModelMapper,
+    Mapper $entityToModelMapper,
   ) {
     /** @var VoidRepository<TEntity> $voidRepository */
     $voidRepository = new VoidRepository();
@@ -28,11 +28,11 @@ class GetRepositoryMapper extends RepositoryMapper {
     $voidMapper = new VoidMapper();
 
     parent::__construct(
-      $this->getRepository,
+      $getRepository,
       $voidRepository,
       $voidRepository,
       $voidMapper,
-      $this->entityToModelMapper,
+      $entityToModelMapper,
     );
   }
 }

--- a/core/src/Repository/Mapper/PaginationOffsetLimitMapper.php
+++ b/core/src/Repository/Mapper/PaginationOffsetLimitMapper.php
@@ -10,6 +10,8 @@ use Harmony\Core\Domain\Pagination\PaginationOffsetLimit;
  * @implements Mapper<PaginationOffsetLimit<TFrom>, PaginationOffsetLimit<TTo>>
  * @psalm-suppress InvalidArgument
  * @psalm-suppress UndefinedDocblockClass
+ * @psalm-suppress InvalidReturnType
+ * @psalm-suppress InvalidReturnStatement
  */
 class PaginationOffsetLimitMapper implements Mapper {
   public function __construct(

--- a/core/src/Repository/PutRepositoryMapper.php
+++ b/core/src/Repository/PutRepositoryMapper.php
@@ -17,21 +17,21 @@ class PutRepositoryMapper extends RepositoryMapper {
    */
   public function __construct(
     // @phpstan-ignore-next-line
-    protected readonly PutRepository $putRepository,
+    PutRepository $putRepository,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $modelToEntityMapper,
+    Mapper $modelToEntityMapper,
     // @phpstan-ignore-next-line
-    protected readonly Mapper $entityToModelMapper,
+    Mapper $entityToModelMapper,
   ) {
     /** @var VoidRepository<TEntity> $voidRepository */
     $voidRepository = new VoidRepository();
 
     parent::__construct(
       $voidRepository,
-      $this->putRepository,
+      $putRepository,
       $voidRepository,
-      $this->modelToEntityMapper,
-      $this->entityToModelMapper,
+      $modelToEntityMapper,
+      $entityToModelMapper,
     );
   }
 }

--- a/core/src/Repository/PutRepositoryMapper.php
+++ b/core/src/Repository/PutRepositoryMapper.php
@@ -16,11 +16,8 @@ class PutRepositoryMapper extends RepositoryMapper {
    * @param Mapper<TEntity, TModel> $entityToModelMapper
    */
   public function __construct(
-    // @phpstan-ignore-next-line
     PutRepository $putRepository,
-    // @phpstan-ignore-next-line
     Mapper $modelToEntityMapper,
-    // @phpstan-ignore-next-line
     Mapper $entityToModelMapper,
   ) {
     /** @var VoidRepository<TEntity> $voidRepository */


### PR DESCRIPTION
* Asana task link: https://app.asana.com/0/1109863238977521/1203843596088104/f

**Merge / Pull request information:**
* Readonly properties in child classes that call parent constructor converted to normal arguments to avoid the error thrown 

